### PR TITLE
Deal with large queries

### DIFF
--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -3,7 +3,7 @@ pipeline:
     image: node:14-alpine
     commands:
       # Need git for pulling some package dependencies (erikap/sparql-client)
-      - apk --no-cache add git ssh
+      - apk --no-cache add git openssh
       - npm ci
       - npm run lint:js
   build:

--- a/.woodpecker/.test-build.yml
+++ b/.woodpecker/.test-build.yml
@@ -3,7 +3,7 @@ pipeline:
     image: node:14-alpine
     commands:
       # Need git for pulling some package dependencies (erikap/sparql-client)
-      - apk --no-cache add git
+      - apk --no-cache add git ssh
       - npm ci
       - npm run lint:js
   build:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ harvesting-execute-diff-deletes:
 To make sure the delta-notifier sends the needed messages, add the following
 snippet to the `rules.js` file:
 
-```json
+```javascript
 {
   match: {
     predicate: {
@@ -100,6 +100,10 @@ Supply a value for them using the `environment` keyword in the
   printed. On `error`, only error messages are printed to the console. On
   `info`, both error messages and informational messages such as data
   processing results are printed. The amount of information might be limited.
+* `MAX_BATCH_SIZE`: *(optional, default: "100")* Deletes are executed in
+  batches. This variable sets the maximum size of such batches. A batch becomes
+  even smaller automatically when errors start occuring to a size of one triple
+  per batch. If there is stil an error, then the whole task will fail.
 * `WRITE_ERRORS`: *(optional, default: "false", boolean)* Indicates if errors
   need to be written to the triplestore.
 * `ERROR_GRAPH`: *(optional, default: "http://lblod.data.gift/errors")* Graph

--- a/env.js
+++ b/env.js
@@ -31,6 +31,11 @@ export const ERROR_BASE = envvar
   .default('http://data.lblod.info/errors/')
   .asUrlString();
 
+export const MAX_BATCH_SIZE = envvar
+  .get('MAX_BATCH_SIZE')
+  .default('100')
+  .asIntPositive();
+
 const PREFIXES = {
   rdf: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
   xsd: 'http://www.w3.org/2001/XMLSchema#',

--- a/lib/deletes.js
+++ b/lib/deletes.js
@@ -31,6 +31,32 @@ export async function executeDeletesFile(deletesFilePh) {
   return executeDeletesStore(toRemoveStore);
 }
 
+export async function executeDeletesStore(store) {
+  const triples = [...store];
+  let batchSize = env.MAX_BATCH_SIZE;
+  let start = 0;
+  while (start < triples.length) {
+    try {
+      const batch = triples.slice(start, start + batchSize);
+      await executeDeletesStoreWithoutBatching(batch);
+      start += batchSize;
+      batchSize = env.MAX_BATCH_SIZE;
+    } catch (err) {
+      if (batchSize > 1) batchSize = Math.ceil(batchSize / 2);
+      else {
+        // We could skip this one triple like so:
+        //start++;
+        // But if not all data can be executed, this whole task should fail:
+        throw new Error(
+          `The following triple could not be removed from the triplestore:\n\t${formatTriple(
+            triples[start]
+          )}\nThis might be because of a network issue, a syntax issue or because the triple is too long.`
+        );
+      }
+    }
+  }
+}
+
 /**
  * Deletes an N3 Store from the triplestore, making sure to use a workaround
  * for deleting typed `xsd:string` in the data.
@@ -43,7 +69,7 @@ export async function executeDeletesFile(deletesFilePh) {
  * @returns {undefined} Nothing. (Might return the response object of a REST
  * call to the triplestore to remove the data.)
  */
-export async function executeDeletesStore(store) {
+async function executeDeletesStoreWithoutBatching(store) {
   if (store.size <= 0) return;
   const writer = new N3.Writer();
   for (const triple of store) writer.addQuad(triple);
@@ -54,7 +80,12 @@ export async function executeDeletesStore(store) {
     });
   });
   const toRemoveStrings = [];
-  for (const triple of store) toRemoveStrings.push(formatTriple(triple));
+  for (const triple of store)
+    if (
+      triple.object.datatype?.value ===
+      'http://www.w3.org/2001/XMLSchema#string'
+    )
+      toRemoveStrings.push(formatTriple(triple));
   return mas.updateSudo(`
     DELETE DATA {
       GRAPH ${rst.termToString(env.TARGET_GRAPH)} {
@@ -103,11 +134,7 @@ function formatTriple(quad) {
  * @returns {String}
  */
 function formatTerm(term) {
-  if (
-    term.datatype?.value === 'http://www.w3.org/2001/XMLSchema#string' ||
-    term.datatype?.value ===
-      'http://www.w3.org/1999/02/22-rdf-syntax-ns#langString'
-  )
+  if (term.datatype?.value === 'http://www.w3.org/2001/XMLSchema#string')
     return `${rst.termToString(term)}^^${rst.termToString(term.datatype)}`;
   else return rst.termToString(term);
 }

--- a/lib/deletes.js
+++ b/lib/deletes.js
@@ -64,8 +64,8 @@ export async function executeDeletesStore(store) {
  * @public
  * @async
  * @function
- * @param {N3.Store} store - Store containing the data that needs to be
- * removed.
+ * @param {N3.Store|Iterable} store - Store or other iterable collection
+ * containing the data that needs to be removed.
  * @returns {undefined} Nothing. (Might return the response object of a REST
  * call to the triplestore to remove the data.)
  */
@@ -79,6 +79,8 @@ async function executeDeletesStoreWithoutBatching(store) {
       else resolve(results);
     });
   });
+  //////////////TO REMOVE start :: when new importer only does implicit strings
+  // Format triples that are about strings with their explicit datatype
   const toRemoveStrings = [];
   for (const triple of store)
     if (
@@ -86,6 +88,7 @@ async function executeDeletesStoreWithoutBatching(store) {
       'http://www.w3.org/2001/XMLSchema#string'
     )
       toRemoveStrings.push(formatTriple(triple));
+  //////////////TO REMOVE end
   return mas.updateSudo(`
     DELETE DATA {
       GRAPH ${rst.termToString(env.TARGET_GRAPH)} {
@@ -95,6 +98,8 @@ async function executeDeletesStoreWithoutBatching(store) {
     }
   `);
 }
+
+////////////////TO REMOVE start :: when new importer only does implicit strings
 
 /**
  * Formats a quad in a Turtle/Notation3-like syntax for use in QPARQL queries.
@@ -138,3 +143,5 @@ function formatTerm(term) {
     return `${rst.termToString(term)}^^${rst.termToString(term.datatype)}`;
   else return rst.termToString(term);
 }
+
+////////////////TO REMOVE end


### PR DESCRIPTION
When large amounts of data need to be removed, this service used to create one large query that would fail if it became too large. That is now fixed. A store of data that is to be removed is now always split in batches of configurable size. If a batch still fails (e.g. inserting looong strings), the batch is split into two again (and again) until a single triple remains. If the single triple fails, then the whole task fails.

**How to test:** I would suggest to harvest a local (large) document, then remove all the content of that file, and harvest it again. All that data should now be deleted; you should see that in the preceding task from the diff service. Inspect logs and the database directly to see if the queries work and if the data is correctly removed.